### PR TITLE
Add navigating between page feature on h and l key

### DIFF
--- a/gss.user.js
+++ b/gss.user.js
@@ -80,6 +80,16 @@ window.addEventListener('keypress', (event) => {
       results[focusIndex].style.cssText = 'padding-left: 8px; border-left: 4px solid red;'
       return;
     }
+
+    if (keyCode === 'KeyL') {
+      document.getElementById('pnnext')?.click();
+      return;
+    }
+
+    if (keyCode === 'KeyH') {
+      document.getElementById('pnprev')?.click();
+      return;
+    }
   }
 });
 


### PR DESCRIPTION
I added l and h key events to handle navigation between pages. By pressing the h and l key, the user can move to the previous page or next page.

Related #2